### PR TITLE
修复在Windows环境下返回的图片id带反斜杠'\'，导致后续无法正确GET图片的问题

### DIFF
--- a/src/api.py
+++ b/src/api.py
@@ -47,7 +47,7 @@ async def text2img(request: fastapi.Request):
 
     if is_json_return:
         return Result(code=0, message="success", data={
-            "id": pic
+            "id": pic.replace('\\', '/')
         })
     else:
         return fastapi.responses.FileResponse(pic, media_type="image/jpeg")


### PR DESCRIPTION
解决了此 issue 的问题：https://github.com/AstrBotDevs/AstrBot/issues/2255